### PR TITLE
Raise plugin- and/or role versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Set up Python 3.
         uses: actions/setup-python@v2
         with:
-          python-version: '3.x'
+          python-version: '3.9.x'
 
       - name: Install pip tools.
         run: |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -40,30 +40,16 @@ jenkins_pv_pipeline_library_debug: false
 
 # Plugins and their versions that must be present for jenkins-pv-pipeline-library
 jenkins_pv_pipeline_library_plugins_present:
-  - name: analysis-model-api
-    version: "10.9.1"
   - name: ansicolor
     version: "1.0.1"
-  - name: antisamy-markup-formatter
-    version: "2.7"
   - name: dashboard-view
     version: "2.18"
-  - name: data-tables-api
-    version: "1.11.3-6"
-  - name: forensics-api
-    version: "1.7.0"
   - name: jacoco
     version: "3.3.1"
-  - name: javadoc
-    version: "1.6"
-  - name: prism-api
-    version: 1.25.0-2
   - name: timestamper
     version: "1.16"
   - name: versionnumber
     version: "1.9"
-  - name: warnings-ng
-    version: "9.11.0"
 
 # Plugins that must be absent for jenkins-pv-pipeline-library
 jenkins_pv_pipeline_library_plugins_absent:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -70,7 +70,6 @@ jenkins_pv_pipeline_library_plugins_present:
 # Plugins that must be absent for jenkins-pv-pipeline-library
 jenkins_pv_pipeline_library_plugins_absent:
   - name: analysis-collector
-  - name: analysis-core
   - name: checkstyle
   - name: findbugs
   - name: pmd

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -40,6 +40,8 @@ jenkins_pv_pipeline_library_debug: false
 
 # Plugins and their versions that must be present for jenkins-pv-pipeline-library
 jenkins_pv_pipeline_library_plugins_present:
+  - name: analysis-core
+    version: "1.95"
   - name: analysis-model-api
     version: "10.9.1"
   - name: ansicolor

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -40,8 +40,6 @@ jenkins_pv_pipeline_library_debug: false
 
 # Plugins and their versions that must be present for jenkins-pv-pipeline-library
 jenkins_pv_pipeline_library_plugins_present:
-  - name: analysis-core
-    version: "1.95"
   - name: analysis-model-api
     version: "10.9.1"
   - name: ansicolor
@@ -69,6 +67,7 @@ jenkins_pv_pipeline_library_plugins_present:
 
 # Plugins that must be absent for jenkins-pv-pipeline-library
 jenkins_pv_pipeline_library_plugins_absent:
+  - name: analysis-core
   - name: analysis-collector
   - name: checkstyle
   - name: findbugs

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -40,45 +40,39 @@ jenkins_pv_pipeline_library_debug: false
 
 # Plugins and their versions that must be present for jenkins-pv-pipeline-library
 jenkins_pv_pipeline_library_plugins_present:
-  - name: analysis-collector
-    version: "2.0.0"
-  - name: analysis-core
-    version: "1.96"
   - name: analysis-model-api
-    version: "10.2.5"
+    version: "10.9.1"
   - name: ansicolor
-    version: "1.0.0"
+    version: "1.0.1"
   - name: antisamy-markup-formatter
-    version: "2.1"
-  - name: checkstyle
-    version: "4.0.0"
+    version: "2.7"
   - name: dashboard-view
-    version: "2.17"
+    version: "2.18"
   - name: data-tables-api
-    version: "1.10.23-3"
-  - name: findbugs
-    version: "5.0.0"
+    version: "1.11.3-6"
   - name: forensics-api
-    version: "1.0.0"
+    version: "1.7.0"
   - name: jacoco
-    version: "3.2.0"
+    version: "3.3.1"
   - name: javadoc
     version: "1.6"
-  - name: maven-plugin
-    version: "3.11"
-  - name: pmd
-    version: "4.0.0"
-  - name: tasks
-    version: "4.53"
+  - name: prism-api
+    version: 1.25.0-2
   - name: timestamper
-    version: "1.13"
+    version: "1.16"
   - name: versionnumber
     version: "1.9"
   - name: warnings-ng
-    version: "9.1.0"
+    version: "9.11.0"
 
 # Plugins that must be absent for jenkins-pv-pipeline-library
-jenkins_pv_pipeline_library_plugins_absent: []
+jenkins_pv_pipeline_library_plugins_absent:
+  - name: analysis-collector
+  - name: analysis-core
+  - name: checkstyle
+  - name: findbugs
+  - name: pmd
+  - name: tasks
 
 # Signatures that need to be approved for jenkins-pv-pipeline-library
 jenkins_pv_pipeline_library_approved_signatures_present: []

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -47,7 +47,7 @@ jenkins_pv_pipeline_library_plugins_present:
   - name: jacoco
     version: "3.3.1"
   - name: timestamper
-    version: "1.16"
+    version: "1.17"
   - name: versionnumber
     version: "1.9"
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -28,7 +28,7 @@ galaxy_info:
 dependencies:
   # install jenkins-pv-pipeline-library specific plugins
   - role: wcm_io_devops.jenkins_pipeline_library
-    version: 2.289.1-1
+    version: 2.319.3-1
     jenkins_pipeline_library_admin_username: "{{ jenkins_pv_pipeline_library_admin_username }}"
     jenkins_pipeline_library_admin_password: "{{ jenkins_pv_pipeline_library_admin_password }}"
     jenkins_pipeline_library_jenkins_home: "{{ jenkins_pv_pipeline_library_jenkins_home }}"


### PR DESCRIPTION
Add/Update plugins for Jenkins 2.319.2

Moved some plugins to https://github.com/wcm-io-devops/ansible-jenkins-pipeline-library

**Removed deprecated plugins:**

* analysis-core
* name: analysis-collector
* name: checkstyle
* name: findbugs
* name: pmd
* name: tasks